### PR TITLE
Attempt to Initialize TalonFXs for drivebase

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2021.1.2"
+    id "edu.wpi.first.GradleRIO" version "2021.3.1"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -3,15 +3,23 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #pragma once
-
-#include <string>
-
+//added from 2021 and Phoenix for falcons
 #include <frc/TimedRobot.h>
 #include <frc/Joystick.h>
-#include <frc/WPILib.h>
-#include "rev/CANSparkMax.h"
 #include <frc/drive/DifferentialDrive.h>
+#include <frc/Compressor.h>
+#include <frc/DoubleSolenoid.h>
 #include <frc/smartdashboard/SendableChooser.h>
+#include <frc/DriverStation.h>
+#include <frc/Timer.h>
+#include <frc/Filesystem.h>
+#include <frc/trajectory/TrajectoryUtil.h>
+#include <frc/controller/RamseteController.h>
+#include <frc/trajectory/TrajectoryGenerator.h>
+
+#include "rev/CANSparkMax.h"
+#include "ctre/Phoenix.h"
+
 
 class Robot : public frc::TimedRobot {
  public:
@@ -30,24 +38,36 @@ class Robot : public frc::TimedRobot {
   frc::SendableChooser<std::string> m_chooser;
   // Miscellaneous Motor IDs
   // Neos only, Falcons are somewhere else
-  const std::int armMotorID = 1;
-  const std::int grabberMotorID = 2;
-  const std::int leftClimbMotorID = 3;
-  const std::int rightClimbMotorID = 4;
+  static const int armMotorDeviceID = 1;
+  static const int grabberMotorDeviceID = 2;
+  static const int leftClimbMotorDeviceID = 3;
+  static const int rightClimbMotorDeviceID = 4;
 
   //TODO: DRIVE CODE
+  //These are two ways I've seen talons initialized, the first set being an augmentation of an initialization of TalonSRX, the second set from the CrossTheRoadELec repository on Github for TalonFX differential drive (both example sets were written in cpp)
+  TalonFX frontRightMotor = {5};
+  TalonFX frontLeftMotor = {6}; 
+  TalonFX backRightMotor = {7};
+  TalonFX backLeftMotor = {8}; 
+
+/*
+  WPI_TalonFX * _rghtFront = new WPI_TalonFX(5);
+	WPI_TalonFX * _rghtFollower = new WPI_TalonFX(7);
+	WPI_TalonFX * _leftFront = new WPI_TalonFX(6);
+	WPI_TalonFX * _leftFollower = new WPI_TalonFX(8);
+*/ 
 
   //"Joystick"
   frc::Joystick m_stick{0};
-  const std::int leftControlStick = 1; //used to move
-  const std::int rightControlStick = 4; //used to rotate
+  static const int leftControlStick = 1; //used to move
+  static const int rightControlStick = 4; //used to rotate
 
   //Binding motors to controllers, season one, episode four
   //Neo motors
-  rev::CANSparkMax m_armMotor{armMotorID, rev::CANSparkMax::MotorType::kBrushless};
-  rev::CANSparkMax m_grabberMotor{grabberMotorID, rev::CANSparkMax::MotorType::kBrushless};
-  rev::CANSparkMax m_leftClimbMotor{leftClimbMotorID, rev::CANSparkMax::MotorType::kBrushless};
-  rev::CANSparkMax m_rightClimbMotor{rightClimbMotorID, rev::CANSparkMax::MotorType::kBrushless};
+  rev::CANSparkMax m_armMotor{armMotorDeviceID, rev::CANSparkMax::MotorType::kBrushless};
+  rev::CANSparkMax m_grabberMotor{grabberMotorDeviceID, rev::CANSparkMax::MotorType::kBrushless};
+  rev::CANSparkMax m_leftClimbMotor{leftClimbMotorDeviceID, rev::CANSparkMax::MotorType::kBrushless};
+  rev::CANSparkMax m_rightClimbMotor{rightClimbMotorDeviceID, rev::CANSparkMax::MotorType::kBrushless};
 
   rev::CANEncoder m_armEncoder = m_armMotor.GetEncoder();
   rev::CANEncoder m_grabberEncoder = m_grabberMotor.GetEncoder();
@@ -56,7 +76,7 @@ class Robot : public frc::TimedRobot {
 
   // Limelight
   //Copied from 2021
-  std::shared_ptr<NetworkTable> m_table = nt::NetworkTableInstance::GetDefault().GetTable("limelight-scorpio");
+  std::shared_ptr<NetworkTable> m_table = nt::NetworkTableInstance::GetDefault().GetTable("limelight-scorpio"); //missing a library?
   double tx_OFFSET = 0.0; // old = 3.0
 
 

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,0 +1,214 @@
+{
+    "fileName": "Phoenix.json",
+    "name": "CTRE-Phoenix",
+    "version": "5.19.4",
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "mavenUrls": [
+        "https://devsite.ctr-electronics.com/maven/release/"
+    ],
+    "jsonUrl": "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-java",
+            "version": "5.19.4"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-java",
+            "version": "5.19.4"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.19.4",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.19.4",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.19.4",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.19.4",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-cpp",
+            "version": "5.19.4",
+            "libName": "CTRE_Phoenix_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-cpp",
+            "version": "5.19.4",
+            "libName": "CTRE_Phoenix",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCCI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCCISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "diagnostics",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixDiagnostics",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "canutils",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCanutils",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "platform-sim",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixPlatform",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "core",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCore",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.19.4",
+            "libName": "CTRE_SimTalonSRX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.19.4",
+            "libName": "CTRE_SimVictorSPX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        }
+    ]
+}

--- a/vendordeps/REVRobotics.json
+++ b/vendordeps/REVRobotics.json
@@ -1,0 +1,73 @@
+{
+    "fileName": "REVRobotics.json",
+    "name": "REVRobotics",
+    "version": "1.5.4",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "mavenUrls": [
+        "http://www.revrobotics.com/content/sw/max/sdk/maven/"
+    ],
+    "jsonUrl": "http://www.revrobotics.com/content/sw/max/sdk/REVRobotics.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "SparkMax-java",
+            "version": "1.5.4"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "SparkMax-driver",
+            "version": "1.5.4",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian",
+                "osxx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "SparkMax-cpp",
+            "version": "1.5.4",
+            "libName": "SparkMax",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "SparkMax-driver",
+            "version": "1.5.4",
+            "libName": "SparkMaxDriver",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian",
+                "osxx86-64"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Minor revisions to variable declarations, added #includes, *a couple attempts to initialize the TalonFXs -- note: error with the Limelight initialization
*There are two ways I've seen so far for initializing talons, the first set is an augmentation of an initialization of TalonSRX, the second set is pulled from the CrossTheRoadELec repository on Github for TalonFX differential drive (both example sets were written in cpp)